### PR TITLE
Added GroupTitleStyle to allow styling of propertyGroups

### DIFF
--- a/src/dataform/index.ts
+++ b/src/dataform/index.ts
@@ -1,6 +1,6 @@
 import { registerElement, registerNativeConfigElement, NativeElementNode, NativeElementPropType, NativeElementPropConfig } from 'svelte-native/dom'
 import { NativeViewElementNode } from "svelte-native/dom";
-import { RadDataForm, DataFormStackLayout, DataFormGridLayout, EntityProperty, PropertyEditor, PropertyEditorParams, PropertyEditorStyle, PropertyGroup, EmailValidator, IsTrueValidator, NonEmptyValidator, MaximumLengthValidator, MinimumLengthValidator, PhoneValidator, RangeValidator, RegExValidator } from 'nativescript-ui-dataform';
+import { RadDataForm, DataFormStackLayout, DataFormGridLayout, EntityProperty, PropertyEditor, PropertyEditorParams, PropertyEditorStyle, PropertyGroup, EmailValidator, IsTrueValidator, NonEmptyValidator, MaximumLengthValidator, MinimumLengthValidator, PhoneValidator, RangeValidator, RegExValidator, GroupTitleStyle } from 'nativescript-ui-dataform';
 
 export default class RadDataFormElement extends NativeViewElementNode<RadDataForm> {
     constructor() {
@@ -32,6 +32,7 @@ export default class RadDataFormElement extends NativeViewElementNode<RadDataFor
         registerConfigElement('PropertyEditorParams', PropertyEditorParams, "params");
         registerConfigElement('PropertyEditorStyle', PropertyEditorStyle, "propertyEditorStyle");
         registerConfigElement('PropertyGroup', PropertyGroup, "groups", { "properties": NativeElementPropType.Array });
+        registerConfigElement('GroupTitleStyle', GroupTitleStyle, "groupTitleStyle");
         registerConfigElement('EmailValidator', EmailValidator, "validators");
         registerConfigElement('IsTrueValidator', IsTrueValidator, "validators");
         registerConfigElement('NonEmptyValidator', NonEmptyValidator, "validators");


### PR DESCRIPTION
So whilst trying to use the RadDataForm I couldn't seem to style Group titles for property groups. This PR basically just registers the GroupTitleStyle object so that it can be used to style groups as shown in example below

```xml
<propertyGroup bind:this={group} collapsible="true" name="Additional Options" hidden="false">
  <propertyGroup.titleStyle>
    <groupTitleStyle fillColor="#ffffff" />
  </propertyGroup.titleStyle>
  <entityProperty name="marks" displayName="Marks" index="3">
    <propertyEditor type="Numeric" />
  </entityProperty>
</propertyGroup>
```

**Edit**: For reference, here's a link to the [NativeScript documentation regarding this](https://docs.nativescript.org/ui/components/dataform/dataform-styling#styling-group-headers) 